### PR TITLE
message_status method should return extended string with status attribute present

### DIFF
--- a/lib/response.rb
+++ b/lib/response.rb
@@ -33,11 +33,11 @@ module TextMagic
         hash.each do |message_id, message_hash|
           status = message_hash["status"].dup
           metaclass = class << status; self; end
-          metaclass.send :attr_accessor, :text, :credits_cost, :reply_number, :message_status, :created_time, :completed_time
+          metaclass.send :attr_accessor, :text, :credits_cost, :reply_number, :status, :created_time, :completed_time
           status.text = message_hash["text"]
           status.credits_cost = message_hash["credits_cost"]
           status.reply_number = message_hash["reply_number"]
-          status.message_status = message_hash["message_status"]
+          status.status = message_hash["status"]
           status.created_time = Time.at(message_hash["created_time"].to_i) if message_hash["created_time"]
           status.completed_time = Time.at(message_hash["completed_time"].to_i) if message_hash["completed_time"]
           response[message_id] = status

--- a/test/test_response.rb
+++ b/test/test_response.rb
@@ -120,6 +120,10 @@ class ResponseTest < Test::Unit::TestCase
     should "have credits_cost" do
       @response.credits_cost.should be_close(@credits_cost, 1e-10)
     end
+
+    should "have status" do
+      @response.status.should == @status
+    end
   end
 
   context "Response to message_status command with multiple ids" do
@@ -170,6 +174,10 @@ class ResponseTest < Test::Unit::TestCase
 
     should "have reply_number for all statuses" do
       @response.values.first.reply_number.should == @reply_number
+    end
+
+    should "have status for all statuses" do
+      @response.values.first.status.should == @status
     end
 
     should "have credits_cost for all statuses" do


### PR DESCRIPTION
Hi,

I've fixed a small bug: in `message_status` method you extend `message_status` attribute and try to read it from response hash, but instead this needs to be `status` (both the attribute name and response hash key). Currently the `message_status` attribute is always nil (since it is not in text magic's api).

I've changed that `message_status` method returned string is extended with `status` attribute with non nil value (as stated in textmagic api, see: http://api.textmagic.com/https-api/textmagic-api-commands#message_status).

Also I've added test to make sure everything works.

Regards,
Alex.
